### PR TITLE
Use abstract class for card directive

### DIFF
--- a/src/app/shared/directives/base-category-card.directive.ts
+++ b/src/app/shared/directives/base-category-card.directive.ts
@@ -4,7 +4,7 @@ import { BaseCategory } from '../models/base-category';
 @Directive({
     selector: '[appBaseCategoryCard]',
 })
-export class BaseCategoryCardDirective<T extends BaseCategory> {
+export abstract class BaseCategoryCardDirective<T extends BaseCategory> {
     @Input() category?: T;
 
     @Output() openCategory = new EventEmitter<T['id']>();

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,12 +1,10 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { MaterialModule } from './material/material.module';
-import { BaseCategoryCardDirective } from './directives/base-category-card.directive';
 import { BaseCategoryCardComponent } from './components/base-category-card/base-category-card.component';
 
 @NgModule({
     declarations: [
-    BaseCategoryCardDirective,
     BaseCategoryCardComponent
   ],
     imports: [CommonModule, MaterialModule],


### PR DESCRIPTION
Ошибка ```'typeof BaseCategoryCardDirective' is not assignable to type 'any[] | Type<any>'``` возникала из-за абстрактного класса в declarations NgModule в src/app/shared/shared.module.ts